### PR TITLE
お気に入り使用回数カウンターの実装（検索結果画面）

### DIFF
--- a/app/views/favorites/search.html.haml
+++ b/app/views/favorites/search.html.haml
@@ -29,6 +29,8 @@
                     %p.text-center
                       %a{:href => favorite.url}
                         %img.img-fluid{:alt => "#", :src => favorite.image}
+                      %div{:id => "links_buttons_#{favorite.id}"}
+                        = render partial: 'links/link', locals: { favorite: favorite, links: @links}
                       = favorite.text
                   .modal-footer
                     =link_to '編集',edit_favorite_path(favorite),class: 'btn btn-warning'


### PR DESCRIPTION
# what
検索結果画面からの詳細ページにカウンターを設置
# why
使用時に常にカウンターを使えるようにするため