### PR TITLE
bootstrap(tooltips)を用いた吹き出しの挿入

### DIFF
--- a/app/views/favorites/search.html.haml
+++ b/app/views/favorites/search.html.haml
@@ -28,7 +28,7 @@
                   .modal-body
                     %p.text-center
                       %a{:href => favorite.url}
-                        %img.img-fluid{:alt => "#", :src => favorite.image}
+                        %img.img-fluid{:alt => "#", :src => favorite.image,"data-toggle"=>"tooltip","data-placement"=>"top","title"=>"クリックすると#{favorite.name}に飛びます" }
                       %div{:id => "links_buttons_#{favorite.id}"}
                         = render partial: 'links/link', locals: { favorite: favorite, links: @links}
                       = favorite.text

--- a/app/views/links/_link.html.haml
+++ b/app/views/links/_link.html.haml
@@ -4,16 +4,16 @@
     .counter-area
       = link_to favorite_link_path(favorite_id: favorite.id ,id: favorite.links[0].id), method: :delete, remote: true do
         .minus_button
-          %button.fa.fa-minus-square-o{type: "submit"}
+          %button.fa.fa-minus-square-o{type: "submit","data-toggle"=>"tooltip","data-placement"=>"top","title"=>"カウントを減らします"}
         
       = link_to favorite_links_path(favorite.id), method: :post, remote: true do
         .plus_button
-          %button.fa.fa-plus-square-o{type: "submit"}
+          %button.fa.fa-plus-square-o{type: "submit","data-toggle"=>"tooltip","data-placement"=>"top","title"=>"使用回数をカウントします。リンク先に飛ぶ前にお使いください。"}
          
 - else
   .counter-area
     %p お気に入り使用回数:#{favorite.links_count}回
     = link_to favorite_links_path(favorite.id), method: :post, remote: true do
       .pulus_button
-        %button.fa.fa-plus-square-o{type: "submit"}
+        %button.fa.fa-plus-square-o{type: "submit","data-toggle"=>"tooltip","data-placement"=>"top","title"=>"使用回数をカウントします。リンク先に飛ぶ前にお使いください。"}
   

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -29,7 +29,7 @@
                   .modal-body
                     %p.text-center
                       %a{:href => favorite.url}
-                        %img.img-fluid{:alt => "#", :src => favorite.image}
+                        %img.img-fluid{:alt => "#", :src => favorite.image,"data-toggle"=>"tooltip","data-placement"=>"top","title"=>"クリックすると#{favorite.name}に飛びます"}
                       %div{:id => "links_buttons_#{favorite.id}"}
                         = render partial: 'links/link', locals: { favorite: favorite, links: @links}
                       = favorite.text


### PR DESCRIPTION
# what
お気に入り詳細画面の画像およびお気に入りカウントボタンに吹き出しを挿入

![61805135122436e78b200240e63aa8dc](https://user-images.githubusercontent.com/52599034/69849924-5c9cf600-12c1-11ea-9ff0-1bfcef092d27.gif)

# why
操作をよりわかりやすくするため