### PR TITLE
並び替え機能の実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,25 +17,3 @@
 //= require bootstrap-sprockets
 //= require_tree .
 
-$(function(){
-  $fileField = $('#file')
- 
-  $($fileField).on('change', $fileField, function(e) {
-    file = e.target.files[0]
-    reader = new FileReader(),
-    $preview = $("#img_field");
- 
-    reader.onload = (function(file) {
-      return function(e) {
-        $preview.empty();
-        $preview.append($('<img>').attr({
-          src: e.target.result,
-          width: "100%",
-          class: "preview",
-          title: file.name
-        }));
-      };
-    })(file);
-    reader.readAsDataURL(file);
-  });
-});

--- a/app/assets/javascripts/products/_seach.js
+++ b/app/assets/javascripts/products/_seach.js
@@ -1,0 +1,66 @@
+$(function(){
+  $fileField = $('#file')
+ 
+  $($fileField).on('change', $fileField, function(e) {
+    file = e.target.files[0]
+    reader = new FileReader(),
+    $preview = $("#img_field");
+ 
+    reader.onload = (function(file) {
+      return function(e) {
+        $preview.empty();
+        $preview.append($('<img>').attr({
+          src: e.target.result,
+          width: "100%",
+          class: "preview",
+          title: file.name
+        }));
+      };
+    })(file);
+    reader.readAsDataURL(file);
+  });
+
+  $('select[name=sort_order]').change(function() {
+
+    var this_value = $(this).val();
+    if (this_value == "created_at_desc") {
+      html = "&sort=created_at+desc"
+    } else if (this_value == "created_at_asc") {
+      html = "&sort=created_at+asc"
+    } else if (this_value == "links_count_desc") {
+      html = "&sort=links_count+desc"
+    } else if (this_value == "links_count_asc") {
+      html = "&sort=links_count+asc"
+    } else {
+      html = ""
+    };
+    var current_html = window.location.href;
+    if (location['href'].match(/&sort=*.+/) != null) {
+      var remove = location['href'].match(/&sort=*.+/)[0]
+      var current_html = current_html.replace(remove, '')
+    };
+    window.location.href = current_html + html
+  });
+  $(function () {
+    if (location['href'].match(/&sort=*.+/) != null) {
+      if ($('select option[selected=selected]')) {
+        $('select option:first').prop('selected', false);
+      }
+
+      var selected_option = location['href'].match(/&sort=*.+/)[0].replace('&sort=', '');
+
+      if(selected_option == "created_at+desc") {
+        var sort = 1
+      } else if (selected_option == "created_at+asc") {
+        var sort = 2
+      } else if (selected_option == "links_count+desc") {
+        var sort = 3
+      } else if (selected_option == "links_count+asc") {
+        var sort = 4
+      }
+
+      var add_selected = $('select[name=sort_order]').children()[sort]
+      $(add_selected).attr('selected', true)
+    }
+  });
+});

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -41,7 +41,8 @@ class FavoritesController < ApplicationController
   def search
     @users = current_user.id
     @favorites = Favorite.search(params[:search])
-    @current_user_favorites=@favorites.where(user_id:@users).page(params[:page])
+    sort = params[:sort] || "created_at DESC"
+    @current_user_favorites=@favorites.where(user_id:@users).page(params[:page]).order(sort)
   end
 
   private

--- a/app/views/favorites/search.html.haml
+++ b/app/views/favorites/search.html.haml
@@ -7,6 +7,17 @@
       .content-title
         %h3.mb-h3 
           #{params[:search]}の検索結果
+        %select{name: :sort_order, class: 'btn btn-default dropdown-toggle'}
+          %option{value: "location.pathname", name: "location.pathname"}
+            並び替え
+          %option{value: "created_at_desc"}
+            登録の新しい順
+          %option{value: "created_at_asc"}
+            登録の古い順
+          %option{value: "links_count_desc"}
+            使用回数の多い順
+          %option{value: "links_count_asc"}
+            使用回数の少ない順
       .row
         - @current_user_favorites.each do |favorite|
           .col-sm-6.col-md-3


### PR DESCRIPTION
# what
検索結果画面にお気に入りの並び替え機能を追加
並び替えは
1.登録日の新しい順
2.登録日の古い順
3.使用回数の多い順
4.使用回数の少ない順
の４種類を実装

![0d1d65fee1f7f5d0bd8e517fe2d06077](https://user-images.githubusercontent.com/52599034/69897371-86701e80-138e-11ea-958d-e987bdf890b9.gif)

＃why
並び替えを追加することで検索機能を充実させ、お気に入りを管理しやすくするため